### PR TITLE
add option to setup applicationInsights with custom options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -28,10 +28,25 @@ Example:
 const writeStream = await insights.createWriteStream({
   key: 'instrumentationkey'
 })
-````
+```
 
 #### key
 
 Type: `String` *(optional)*
 
 The Instrumentation Key of the Azure Application Insights account. If not specified, defaults to APPINSIGHTS_INSTRUMENTATIONKEY environment variable.
+
+Or you could configure Azure Application Insights with your custom preferences by passing `setup` callback property:
+
+```js
+const writeStream = await insights.createWriteStream({
+  setup: (applicationInsights) =>
+    applicationInsights
+      .setup('instrumentationkey')
+      .setAutoCollectRequests(false)        
+      .setAutoCollectDependencies(false)
+      .start()
+})
+```
+
+The only parameter of the callback is the applicationInsights instate to setup and call `start` on.

--- a/src/applicationinsights.js
+++ b/src/applicationinsights.js
@@ -5,8 +5,12 @@ const stream = require('stream')
 
 class Client {
   constructor (options = {}) {
-    const iKey = options.key || process.env.APPINSIGHTS_INSTRUMENTATIONKEY
-    appInsights.setup(iKey).start()
+    if (options.setup) {
+      options.setup(appInsights)
+    } else {
+      const iKey = options.key || process.env.APPINSIGHTS_INSTRUMENTATIONKEY
+      appInsights.setup(iKey).start()
+    }
     this.insights = appInsights.defaultClient
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const streams = require('./streams')
 const pumpify = require('pumpify')
 
 async function createWriteStream (options = {}) {
-  if (!options.key && !process.env.APPINSIGHTS_INSTRUMENTATIONKEY) { throw Error('Instrumentation key missing') }
+  if (!options.setup && !options.key && !process.env.APPINSIGHTS_INSTRUMENTATIONKEY) { throw Error('Instrumentation key missing') }
   const client = new insights.Client(options)
 
   const parseJsonStream = streams.parseJsonStream()

--- a/test/applicationinsights.test.js
+++ b/test/applicationinsights.test.js
@@ -11,6 +11,18 @@ test('creates client', t => {
   t.end()
 })
 
+test('creates client with custom applicationInsights', t => {
+  const client = new tested.Client({
+    setup: insights => {
+      insights.setup('blablabla').setUseDiskRetryCaching(false).start()
+      insights.defaultClient.config.endpointUrl = 'https://custom.endpoint'
+    }
+  })
+  t.equals(client.insights.config.instrumentationKey, 'blablabla')
+  t.equals(client.insights.config.endpointUrl, 'https://custom.endpoint')
+  t.end()
+})
+
 test('gets exception from log', t => {
   const input = [
     { level: 10, time: 1532081790710, msg: 'trace message' },


### PR DESCRIPTION
Right now there is only one option to pass to application insights that is `Instrumentation Key`. This change adds possibility to configure application insights manually like:

```js
const writeStream = await insights.createWriteStream({
  setup: (applicationInsights) =>
    applicationInsights
      .setup('instrumentationkey')
      .setAutoCollectRequests(false)        
      .setAutoCollectDependencies(false)
      .start()
})
```

Case for this is that we would like to disable some default behaviors like `setAutoCollectDependencies(false)`